### PR TITLE
Use 'color' attribute instead of 'pencolor' for edges

### DIFF
--- a/Sources/GraphViz/Edge.swift
+++ b/Sources/GraphViz/Edge.swift
@@ -149,7 +149,7 @@ extension Edge {
         public var style: Style?
 
         /// > Basic drawing color for graphics.
-        @Attribute("pencolor")
+        @Attribute("color")
         public var strokeColor: Color?
 
         /**


### PR DESCRIPTION
The GraphViz docs define 'pencolor' as an attribute to be used for
bounding boxes, not, however, as a general color for edge strokes.

This fixes an issue that edges are not colored correctly.

See:
- https://graphviz.org/doc/info/attrs.html#d:pencolor
- https://graphviz.org/doc/info/attrs.html#d:color