### PR TITLE
Fix node fill colors

### DIFF
--- a/Sources/DOT/DOTRepresentable.swift
+++ b/Sources/DOT/DOTRepresentable.swift
@@ -177,9 +177,9 @@ extension Subgraph.Style: DOTRepresentable {
             return "bold"
         case .rounded:
             return "rounded"
-        case .filled(_):
+        case .filled:
             return "filled"
-        case .striped(_):
+        case .striped:
             return "striped"
         case .compound(let styles):
             return styles.compactMap { $0.representation(in: graph) }.joined(separator: ",")
@@ -208,11 +208,11 @@ extension Node.Style: DOTRepresentable {
             return "rounded"
         case .diagonals:
             return "diagonals"
-        case .filled(_):
+        case .filled:
             return "filled"
-        case .striped(_):
+        case .striped:
             return "striped"
-        case .wedged(_):
+        case .wedged:
             return "wedged"
         case .compound(let styles):
             return styles.compactMap { $0.representation(in: graph) }.joined(separator: ",")

--- a/Sources/GraphViz/Node.swift
+++ b/Sources/GraphViz/Node.swift
@@ -71,9 +71,9 @@ extension Node {
         case bold
         case rounded
         case diagonals
-        case filled(Color)
-        case striped([Color])
-        case wedged([Color])
+        case filled
+        case striped
+        case wedged
         case compound([Style])
     }
 
@@ -155,21 +155,10 @@ extension Node {
 
         /// - Important: Setting fillColor sets `style` to .filled;
         ///              setting `nil` fillColor sets `style` to `nil`
+        @Attribute("fillcolor")
         public var fillColor: Color? {
-            get {
-                if case let .filled(color)? = style {
-                    return color
-                } else {
-                    return nil
-                }
-            }
-
-            set {
-                if let color = newValue {
-                    style = .filled(color)
-                } else {
-                    style = nil
-                }
+            willSet {
+                style = newValue.map { _ in .filled }
             }
         }
 

--- a/Sources/GraphViz/Node.swift
+++ b/Sources/GraphViz/Node.swift
@@ -356,6 +356,7 @@ extension Node.Attributes {
             _sortValue,
             _width,
             _height,
+            _fillColor,
             _fixedSize,
             _shape,
             _style,

--- a/Sources/GraphViz/Subgraph.swift
+++ b/Sources/GraphViz/Subgraph.swift
@@ -240,6 +240,7 @@ extension Subgraph.Attributes {
             _backgroundColor,
             _borderColor,
             _borderWidth,
+            _fillColor,
             _href,
             _url,
             _fontName,

--- a/Sources/GraphViz/Subgraph.swift
+++ b/Sources/GraphViz/Subgraph.swift
@@ -68,8 +68,8 @@ extension Subgraph {
         case dotted
         case bold
         case rounded
-        case filled(Color)
-        case striped([Color])
+        case filled
+        case striped
         case compound([Style])
     }
 
@@ -127,21 +127,10 @@ extension Subgraph {
 
         /// - Important: Setting fillColor sets `style` to .filled;
         ///              setting `nil` fillColor sets `style` to `nil`
+        @Attribute("fillcolor")
         public var fillColor: Color? {
-            get {
-                if case let .filled(color)? = style {
-                    return color
-                } else {
-                    return nil
-                }
-            }
-
-            set {
-                if let color = newValue {
-                    style = .filled(color)
-                } else {
-                    style = nil
-                }
+            willSet {
+                style = newValue.map { _ in .filled }
             }
         }
 


### PR DESCRIPTION
The DOT renderer currently ignores the colors in the `Style` cases, so using a custom fill color is not possible:

```swift
extension Subgraph.Style: DOTRepresentable {
    func representation(in graph: Graph) -> String? {
        switch self {
        ...
        case .filled(_):
            return "filled"
        case .striped(_):
            return "striped"
        ...
    }
}
```

Since the colors associated with a style are not represented in the style itself, but using external attributes (like `fillcolor`), it feels more natural to use `fillColor` as a separate attribute in `Node`/`Subgraph` too and instead rely on property observers to ensure that the style is `.filled`:

```swift
@Attribute("fillcolor")
public var fillColor: Color? {
    willSet {
        style = newValue.map { _ in .filled }
    }
}
```

This comes however with the caveat that gradients cannot yet be properly expressed. Since the GraphViz' DOT DSL apparently accepts both single colors and lists of colors, maybe we should use lists of colors instead?

See also:
* https://graphviz.org/doc/info/attrs.html#k:colorList