### PR TITLE
Add more Node Shapes cases

### DIFF
--- a/Sources/GraphViz/Node.swift
+++ b/Sources/GraphViz/Node.swift
@@ -39,7 +39,7 @@ public struct Node: Identifiable, Hashable {
 
 extension Node {
     public enum Shape: String, Hashable {
-        case box, circle, ellipse, point, egg, triangle, plaintext, diamond, trapezium, parallelogram, house, hexagon, octagon, doublecircle, doubleoctagon, invtriangle, invtrapezium, invhouse, Mdiamond, Msquare, Mcircle
+        case box, rectangle, square, circle, ellipse, point, egg, triangle, plaintext, plain, diamond, trapezium, parallelogram, house, hexagon, octagon, doublecircle, doubleoctagon, invtriangle, invtrapezium, invhouse, Mdiamond, Msquare, Mcircle, polygon, oval, star, cylinder, note, tab, folder, box3d, component, cds, signature
     }
 
     public enum ImagePosition: String {


### PR DESCRIPTION
This PR adds a few shapes that weren't yet declared in the `Node.Shape` enum, as `box3d`, `cylinder`, `rectangle`, and a few more. 

[In this link one can see more types](https://graphviz.org/doc/info/shapes.html), I added the ones which I found more interesting and weren't available yet here.

[Tuist](tuist.io) has a very interesting [graph command](https://tuist.io/docs/commands/graph/), which can draw the dependency graph of an Xcode project or workspace. Having different types of shapes like a box and cylinder helps differentiate the different types of targets (App, App Extension, Swift Package, or frameworks, and others) and better understand the dependency tree. We are also using the commits from #6 , so thanks for your fix, @fwcd !