### PR TITLE
Reimplement GraphViz rendering using private serial queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ var b_c = Edge(from: b, to: c)
 b_c.constraint = false
 graph.append(b_c)
 
-// Render image using dot layout algorithm
-let data = try! DOTRenderer(using: .dot, to: .svg).render(graph: graph)
-let svg = String(data: data, encoding: .utf8)!
+// Render image to SVG using dot layout algorithm
+graph.render(using: .dot, to: .svg) { result in 
+  guard .success(let data) = result,
+        let svg = String(data: data, encoding: .utf8)
+  else { return }
+
+  print(svg)
+}
 ```
 
 <img src="https://user-images.githubusercontent.com/7659/76256368-108d1600-620d-11ea-9263-d3ca3cc68d8d.png" alt="Example GraphViz Output" width="150" align="right">
@@ -42,9 +47,8 @@ digraph {
 ```
 
 > **Note**:
-> The `render(using:to:)` method requires that
-> the GraphViz binary corresponding to the specified layout algorithm
-> is accessible from the current `$PATH`.
+> `render(using:to:)` and related methods require
+> GraphViz to be installed on your system.
 
 ### Using Function Builders, Custom Operators, and Fluent Attribute Setters
 

--- a/Sources/Tools/Extensions/Graph+Rendering.swift
+++ b/Sources/Tools/Extensions/Graph+Rendering.swift
@@ -1,4 +1,6 @@
 import Foundation
+import Dispatch
+
 import Core
 
 extension Graph {
@@ -11,7 +13,12 @@ extension Graph {
         - options: The rendering options.
      - Throws: `CocoaError` if the corresponding GraphViz tool isn't available.
      */
-    public func render(using layout: LayoutAlgorithm, to format: Format, with options: Renderer.Options = []) throws -> Data {
-        return try Renderer(layout: layout).render(graph: self, to: format)
+    public func render(using layout: LayoutAlgorithm,
+                       to format: Format,
+                       with options: Renderer.Options = [],
+                       on queue: DispatchQueue = .main,
+                       completion: (@escaping (Result<Data, Swift.Error>) -> Void))
+    {
+        Renderer(layout: layout).render(graph: self, to: format, completion: completion)
     }
 }

--- a/Tests/GraphVizTests/RenderingTests.swift
+++ b/Tests/GraphVizTests/RenderingTests.swift
@@ -14,34 +14,32 @@ final class RenderingTests: XCTestCase {
         return graph
     }()
 
-    func testRendererWithLayout() throws {
-        let data: Data
+    func testGraphRendering() throws {
+        graph.render(using: .dot, to: .svg) { result in
+            switch result {
+            case .success(let data):
+                let svg = String(data: data, encoding: .utf8)!
 
-        do {
-            let renderer = Renderer(layout: .dot)
-            data = try renderer.render(graph: graph, to: .svg)
-        } catch {
-            throw XCTSkip(error.localizedDescription)
+                XCTAssert(svg.starts(with: "<?xml"))
+                XCTAssertGreaterThan(svg.count, 100)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
         }
-
-        let svg = String(data: data, encoding: .utf8)!
-
-        XCTAssert(svg.starts(with: "<?xml"))
-        XCTAssertGreaterThan(svg.count, 100)
     }
 
-    func testGraphRendering() throws {
-        let data: Data
+    func testRendererWithRenderer() throws {
+        let renderer = Renderer(layout: .dot)
+        renderer.render(graph: graph, to: .svg) { result in
+            switch result {
+            case .success(let data):
+                let svg = String(data: data, encoding: .utf8)!
 
-        do {
-            data = try graph.render(using: .dot, to: .svg)
-        } catch {
-            throw XCTSkip(error.localizedDescription)
+                XCTAssert(svg.starts(with: "<?xml"))
+                XCTAssertGreaterThan(svg.count, 100)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
         }
-
-        let svg = String(data: data, encoding: .utf8)!
-
-        XCTAssert(svg.starts(with: "<?xml"))
-        XCTAssertGreaterThan(svg.count, 100)
     }
 }


### PR DESCRIPTION
In the process of integrating #13 into @SwiftDocOrg/swift-doc, I learned (the hard way) that`libgraphviz` is not thread-safe.

```terminal
$ man cgraph | grep thread
       The library is not thread safe.
```

This PR makes the `render` method calls asynchronous, and performs all cgraph operations in a private serial queue.