### PR TITLE
build: silence an annoying warning on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,25 @@
 
 import PackageDescription
 
+#if os(Windows)
+let systemLibraries: [Target] = [
+    .systemLibrary(
+        name: "Clibgraphviz"
+    )
+]
+#else
+let systemLibraries: [Target] = [
+    .systemLibrary(
+        name: "Clibgraphviz",
+        pkgConfig: "libcgraph",
+        providers: [
+          .brew(["graphviz"]),
+          .apt(["graphviz-dev"]),
+        ]
+    ),
+]
+#endif
+
 let package = Package(
     name: "GraphViz",
     products: [
@@ -15,11 +34,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
     ],
-    targets: [
-        .systemLibrary(name: "Clibgraphviz", pkgConfig: "libcgraph", providers: [
-            .brew(["graphviz"]),
-            .apt(["graphviz-dev"])
-        ]),
+    targets: systemLibraries + [
         .target(
             name: "GraphViz",
             dependencies: ["Core", "DOT", "Builder", "Tools"]),


### PR DESCRIPTION
This alteration to Package.swift mirrors the changes that were done in
the SwiftDocOrg/Markup package.  It removes the pkg-config, brew
providers to silence some warnings when building on Windows.  These
tools are normally not distributed on Windows, and require that the user
manually pass along the graphviz installation path.

This is preparatory work, there is further fixes required to enable the
use of this package on Windows.