### PR TITLE
Clibgraphviz: repair the modular build

### DIFF
--- a/Sources/Clibgraphviz/xdot.h
+++ b/Sources/Clibgraphviz/xdot.h
@@ -13,9 +13,6 @@
 #ifndef XDOT_H
 #define XDOT_H
 #include <stdio.h>
-#ifdef _WIN32
-#include <windows.h>
-#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
For some reason the module build seems to differ for WinSDK and the
clibgraphviz which includes `Windows.h`.  This header is unnecessary and
has been pushed upstream
(https://gitlab.com/graphviz/graphviz/-/merge_requests/1930) as well for
removal.  This enables us to build the module on Windows.