### PR TITLE
Revert "Conditionally compile call to gvToolTred on Windows"

### DIFF
--- a/Sources/GraphViz/Tools/Renderer.swift
+++ b/Sources/GraphViz/Tools/Renderer.swift
@@ -26,8 +26,6 @@ public class Renderer {
          a preprocessor to dot to reduce clutter in dense layouts.
 
          Undirected graphs are silently ignored.
-
-         - Important: This functionality isn't available on Windows.
          */
         static let removeEdgesImpliedByTransitivity = Options(rawValue: 1 << 0)
     }
@@ -92,11 +90,9 @@ public class Renderer {
                     try attempt { agmemread(cString) }
                 }
 
-                #if !os(Windows)
                 if options.contains(.removeEdgesImpliedByTransitivity) {
                     try attempt { gvToolTred(graph) }
                 }
-                #endif
 
                 try layout.rawValue.withCString { cString in
                     try attempt { gvLayout(context, graph, cString) }


### PR DESCRIPTION
This reverts commit 8c791194f77c32038362d1d3ee60d035525e6468.  The
changes necessary to support this have been merged upstream.  An updated
build of GraphViz should be sufficient to enable support for this.